### PR TITLE
Fix: fid overlap

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,74 +1,35 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
-#
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
-#
-name: "CodeQL"
+name: "Code Scanning - Action"
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ "main" ]
-  schedule:
-    - cron: '43 2 * * 2'
+    paths:
+      - "**.go"
+  push:
+    branches: [ master ]
+    paths:
+      - "**.go"
 
 jobs:
-  analyze:
-    name: Analyze
+  CodeQL-Build:
     runs-on: ubuntu-latest
     permissions:
       actions: read
       contents: read
       security-events: write
 
-    strategy:
-      fail-fast: false
-      matrix:
-        language: [ 'go' ]
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
-        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
-
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3.3.0
+      - name: Checkout repository
+        uses: actions/checkout@v3.1.0
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: 'go'
+          queries: crypto-com/cosmos-sdk-codeql@main,security-and-quality
 
-        # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v2
 
-
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-
-    #   If the Autobuild fails above, remove it and uncomment the following three lines.
-    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
-
-    # - run: |
-    #   echo "Run, Build Application using script"
-    #   ./location_of_script_within_repo/buildscript.sh
-
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
-      with:
-        category: "/language:${{matrix.language}}"
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,7 +5,7 @@ on:
     paths:
       - "**.go"
   push:
-    branches: [ master ]
+    branches: [ main ]
     paths:
       - "**.go"
 

--- a/jprov/jprovd/client_commands.go
+++ b/jprov/jprovd/client_commands.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/JackalLabs/jackal-provider/jprov/crypto"
@@ -17,8 +18,6 @@ import (
 	"github.com/cosmos/go-bip39"
 	stortypes "github.com/jackalLabs/canine-chain/x/storage/types"
 	"github.com/spf13/cobra"
-
-	"errors"
 )
 
 func ClientCmd() *cobra.Command {
@@ -46,7 +45,6 @@ func WithdrawCommand() *cobra.Command {
 		Short: "Withdraw tokens to a specified account.",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
-
 			clientCtx, err := client.GetClientTxContext(cmd)
 			if err != nil {
 				return err
@@ -174,7 +172,7 @@ func GenKeyCommand() *cobra.Command {
 
 			pKey := secp256k1.GenPrivKeyFromSecret([]byte(mnemonic))
 
-			//pKey := secp256k1.GenPrivKey()
+			// pKey := secp256k1.GenPrivKey()
 			address, err := bech32.ConvertAndEncode(stortypes.AddressPrefix, pKey.PubKey().Address().Bytes())
 			if err != nil {
 				return err
@@ -252,7 +250,7 @@ func ImportKeyCommand() *cobra.Command {
 
 			pKey := secp256k1.GenPrivKeyFromSecret([]byte(mnemonic))
 
-			//pKey := secp256k1.GenPrivKey()
+			// pKey := secp256k1.GenPrivKey()
 			address, err := bech32.ConvertAndEncode(stortypes.AddressPrefix, pKey.PubKey().Address().Bytes())
 			if err != nil {
 				return err

--- a/jprov/server/http.go
+++ b/jprov/server/http.go
@@ -14,15 +14,15 @@ import (
 
 	"github.com/julienschmidt/httprouter"
 
-	api "github.com/JackalLabs/jackal-provider/jprov/api"
+	"github.com/JackalLabs/jackal-provider/jprov/api"
 	"github.com/JackalLabs/jackal-provider/jprov/crypto"
 	"github.com/JackalLabs/jackal-provider/jprov/queue"
-	types "github.com/JackalLabs/jackal-provider/jprov/types"
+	"github.com/JackalLabs/jackal-provider/jprov/types"
 	"github.com/JackalLabs/jackal-provider/jprov/utils"
 	"github.com/spf13/cobra"
 )
 
-func indexres(cmd *cobra.Command, w http.ResponseWriter, r *http.Request, ps httprouter.Params, q *queue.UploadQueue) {
+func indexres(cmd *cobra.Command, w http.ResponseWriter) {
 	clientCtx, err := client.GetClientTxContext(cmd)
 	ctx := utils.GetServerContextFromCmd(cmd)
 	if err != nil {
@@ -46,7 +46,7 @@ func indexres(cmd *cobra.Command, w http.ResponseWriter, r *http.Request, ps htt
 	}
 }
 
-func checkVersion(w http.ResponseWriter, r *http.Request, ps httprouter.Params, ctx *utils.Context) {
+func checkVersion(w http.ResponseWriter, ctx *utils.Context) {
 	v := types.VersionResponse{
 		Version: version.Version,
 	}
@@ -56,7 +56,7 @@ func checkVersion(w http.ResponseWriter, r *http.Request, ps httprouter.Params, 
 	}
 }
 
-func downfil(cmd *cobra.Command, w http.ResponseWriter, r *http.Request, ps httprouter.Params, ctx *utils.Context) {
+func downfil(cmd *cobra.Command, w http.ResponseWriter, ps httprouter.Params, ctx *utils.Context) {
 	clientCtx := client.GetClientContextFromCmd(cmd)
 
 	files, err := os.ReadDir(utils.GetStoragePath(clientCtx, ps.ByName("file")))
@@ -91,15 +91,15 @@ func GetRoutes(cmd *cobra.Command, router *httprouter.Router, db *leveldb.DB, q 
 	ctx := utils.GetServerContextFromCmd(cmd)
 
 	dfil := func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
-		downfil(cmd, w, r, ps, ctx)
+		downfil(cmd, w, ps, ctx)
 	}
 
 	ires := func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
-		indexres(cmd, w, r, ps, q)
+		indexres(cmd, w)
 	}
 
 	router.GET("/version", func(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
-		checkVersion(w, r, p, ctx)
+		checkVersion(w, ctx)
 	})
 	router.GET("/download/:file", dfil)
 
@@ -110,7 +110,7 @@ func GetRoutes(cmd *cobra.Command, router *httprouter.Router, db *leveldb.DB, q 
 
 func PostRoutes(cmd *cobra.Command, router *httprouter.Router, db *leveldb.DB, q *queue.UploadQueue) {
 	upfil := func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
-		fileUpload(&w, r, ps, cmd, db, q)
+		fileUpload(&w, r, cmd, db, q)
 	}
 
 	router.POST("/upload", upfil)
@@ -119,7 +119,7 @@ func PostRoutes(cmd *cobra.Command, router *httprouter.Router, db *leveldb.DB, q
 
 // This function returns the filename(to save in database) of the saved file
 // or an error if it occurs
-func fileUpload(w *http.ResponseWriter, r *http.Request, ps httprouter.Params, cmd *cobra.Command, db *leveldb.DB, q *queue.UploadQueue) {
+func fileUpload(w *http.ResponseWriter, r *http.Request, cmd *cobra.Command, db *leveldb.DB, q *queue.UploadQueue) {
 	ctx := utils.GetServerContextFromCmd(cmd)
 
 	// ParseMultipartForm parses a request body as multipart/form-data

--- a/jprov/server/proofs.go
+++ b/jprov/server/proofs.go
@@ -179,6 +179,12 @@ func postProofs(cmd *cobra.Command, db *leveldb.DB, q *queue.UploadQueue, ctx *u
 
 	const maxMisses = 8
 
+	address, err := crypto.GetAddress(clientCtx)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
 	for {
 
 		iter := db.NewIterator(nil, nil)
@@ -196,7 +202,7 @@ func postProofs(cmd *cobra.Command, db *leveldb.DB, q *queue.UploadQueue, ctx *u
 
 			ctx.Logger.Debug(fmt.Sprintf("CID: %s", cid))
 
-			ver, verr := checkVerified(&clientCtx, cid)
+			ver, verr := checkVerified(&clientCtx, cid, address)
 			if verr != nil {
 				ctx.Logger.Error(verr.Error())
 				rr := strings.Contains(verr.Error(), "key not found")

--- a/jprov/server/proofs.go
+++ b/jprov/server/proofs.go
@@ -206,7 +206,8 @@ func postProofs(cmd *cobra.Command, db *leveldb.DB, q *queue.UploadQueue, ctx *u
 			if verr != nil {
 				ctx.Logger.Error(verr.Error())
 				rr := strings.Contains(verr.Error(), "key not found")
-				if !rr {
+				ny := strings.Contains(verr.Error(), ErrNotYours)
+				if !rr && !ny {
 					continue
 				}
 				val, err := db.Get(utils.MakeDowntimeKey(cid), nil)

--- a/jprov/server/utils.go
+++ b/jprov/server/utils.go
@@ -75,7 +75,7 @@ func queryBlock(clientCtx *client.Context, cid string) (string, error) {
 	return res.ActiveDeals.Blocktoprove, nil
 }
 
-func checkVerified(clientCtx *client.Context, cid string) (bool, error) {
+func checkVerified(clientCtx *client.Context, cid string, self string) (bool, error) {
 	queryClient := storageTypes.NewQueryClient(clientCtx)
 
 	argCid := cid
@@ -93,6 +93,10 @@ func checkVerified(clientCtx *client.Context, cid string) (bool, error) {
 	ver, err := strconv.ParseBool(res.ActiveDeals.Proofverified)
 	if err != nil {
 		return false, err
+	}
+
+	if res.ActiveDeals.Provider != self {
+		return false, fmt.Errorf("not your deal, get rid of it")
 	}
 
 	return ver, nil

--- a/jprov/server/utils.go
+++ b/jprov/server/utils.go
@@ -1,0 +1,99 @@
+package server
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/JackalLabs/jackal-provider/jprov/utils"
+	"github.com/cosmos/cosmos-sdk/client"
+	storageTypes "github.com/jackalLabs/canine-chain/x/storage/types"
+	"github.com/spf13/cobra"
+	"github.com/wealdtech/go-merkletree"
+)
+
+func HashData(cmd *cobra.Command, fid string) (string, string, error) {
+	clientCtx := client.GetClientContextFromCmd(cmd)
+	ctx := utils.GetServerContextFromCmd(cmd)
+	path := utils.GetStoragePath(clientCtx, fid)
+	files, err := os.ReadDir(filepath.Clean(path))
+	if err != nil {
+		ctx.Logger.Error(err.Error())
+	}
+	size := 0
+	var list [][]byte
+
+	for i := 0; i < len(files); i++ {
+
+		path := filepath.Join(utils.GetStoragePath(clientCtx, fid), fmt.Sprintf("%d.jkl", i))
+
+		dat, err := os.ReadFile(filepath.Clean(path))
+		if err != nil {
+			ctx.Logger.Error(err.Error())
+		}
+
+		size = size + len(dat)
+
+		h := sha256.New()
+		_, err = io.WriteString(h, fmt.Sprintf("%d%x", i, dat))
+		if err != nil {
+			return "", "", err
+		}
+		hashName := h.Sum(nil)
+
+		list = append(list, hashName)
+
+	}
+
+	t, err := merkletree.New(list)
+	if err != nil {
+		ctx.Logger.Error(err.Error())
+	}
+
+	return hex.EncodeToString(t.Root()), fmt.Sprintf("%d", size), nil
+}
+
+func queryBlock(clientCtx *client.Context, cid string) (string, error) {
+	queryClient := storageTypes.NewQueryClient(clientCtx)
+
+	argCid := cid
+
+	params := &storageTypes.QueryActiveDealRequest{
+		Cid: argCid,
+	}
+
+	res, err := queryClient.ActiveDeals(context.Background(), params)
+	if err != nil {
+		return "", err
+	}
+
+	return res.ActiveDeals.Blocktoprove, nil
+}
+
+func checkVerified(clientCtx *client.Context, cid string) (bool, error) {
+	queryClient := storageTypes.NewQueryClient(clientCtx)
+
+	argCid := cid
+
+	params := &storageTypes.QueryActiveDealRequest{
+		Cid: argCid,
+	}
+
+	res, err := queryClient.ActiveDeals(context.Background(), params)
+
+	if err != nil {
+		return false, err
+	}
+
+	ver, err := strconv.ParseBool(res.ActiveDeals.Proofverified)
+	if err != nil {
+		return false, err
+	}
+
+	return ver, nil
+}

--- a/jprov/server/utils.go
+++ b/jprov/server/utils.go
@@ -87,7 +87,6 @@ func checkVerified(clientCtx *client.Context, cid string, self string) (bool, er
 	}
 
 	res, err := queryClient.ActiveDeals(context.Background(), params)
-
 	if err != nil {
 		return false, err
 	}

--- a/jprov/server/utils.go
+++ b/jprov/server/utils.go
@@ -17,6 +17,8 @@ import (
 	"github.com/wealdtech/go-merkletree"
 )
 
+const ErrNotYours = "not your deal"
+
 func HashData(cmd *cobra.Command, fid string) (string, string, error) {
 	clientCtx := client.GetClientContextFromCmd(cmd)
 	ctx := utils.GetServerContextFromCmd(cmd)
@@ -96,7 +98,7 @@ func checkVerified(clientCtx *client.Context, cid string, self string) (bool, er
 	}
 
 	if res.ActiveDeals.Provider != self {
-		return false, fmt.Errorf("not your deal, get rid of it")
+		return false, fmt.Errorf(ErrNotYours)
 	}
 
 	return ver, nil

--- a/jprov/utils/tx.go
+++ b/jprov/utils/tx.go
@@ -1,9 +1,6 @@
 package utils
 
 import (
-	"fmt"
-	"os"
-
 	"github.com/JackalLabs/jackal-provider/jprov/crypto"
 	"github.com/cosmos/cosmos-sdk/client"
 	txns "github.com/cosmos/cosmos-sdk/client/tx"
@@ -50,6 +47,7 @@ func prepareFactory(clientCtx client.Context, txf txns.Factory) (txns.Factory, e
 
 func SendTx(clientCtx client.Context, flagSet *pflag.FlagSet, msgs ...sdk.Msg) (*sdk.TxResponse, error) {
 	txf := txns.NewFactoryCLI(clientCtx, flagSet)
+
 	txf, err := prepareFactory(clientCtx, txf)
 	if err != nil {
 		return nil, err
@@ -60,15 +58,7 @@ func SendTx(clientCtx client.Context, flagSet *pflag.FlagSet, msgs ...sdk.Msg) (
 		return nil, err
 	}
 
-	if txf.SimulateAndExecute() || clientCtx.Simulate {
-		_, adjusted, err := txns.CalculateGas(clientCtx, txf, msgs...)
-		if err != nil {
-			return nil, err
-		}
-
-		txf = txf.WithGas(adjusted)
-		_, _ = fmt.Fprintf(os.Stderr, "%s\n", txns.GasEstimateResponse{GasEstimate: txf.Gas()})
-	}
+	txf = txf.WithGas(uint64(2000000 * (len(msgs) + 1)))
 
 	if clientCtx.Simulate {
 		return nil, nil


### PR DESCRIPTION
Sometimes providers will refuse new deals due to a stray already being on the system even if another provider claimed it causing missed proofs.