### PR TITLE
Fixed all issues with proofs

### DIFF
--- a/jprov/server/proofs.go
+++ b/jprov/server/proofs.go
@@ -79,8 +79,6 @@ func CreateMerkleForProof(clientCtx client.Context, filename string, index int64
 		return "", "", err
 	}
 
-	ctx.Logger.Info(fmt.Sprintf("Merkle Root: %x", tree.Root()))
-
 	h := sha256.New()
 	_, err = io.WriteString(h, fmt.Sprintf("%d%x", index, item))
 	if err != nil {

--- a/jprov/server/utils.go
+++ b/jprov/server/utils.go
@@ -15,6 +15,7 @@ import (
 	storageTypes "github.com/jackalLabs/canine-chain/x/storage/types"
 	"github.com/spf13/cobra"
 	"github.com/wealdtech/go-merkletree"
+	"github.com/wealdtech/go-merkletree/sha3"
 )
 
 const ErrNotYours = "not your deal"
@@ -52,7 +53,7 @@ func HashData(cmd *cobra.Command, fid string) (string, string, error) {
 
 	}
 
-	t, err := merkletree.New(list)
+	t, err := merkletree.NewUsing(list, sha3.New512(), false)
 	if err != nil {
 		ctx.Logger.Error(err.Error())
 	}


### PR DESCRIPTION
Somehow merkleTree.New() never got updated to merkleTree.NewUsing() like the core chain it relies on. Should in the future change this all to be a library built into the core chain so that we can import it into other modules.