### PR TITLE
Stray multi-threaded signing queue

### DIFF
--- a/jprov/strays/stray_manager.go
+++ b/jprov/strays/stray_manager.go
@@ -1,0 +1,28 @@
+package strays
+
+func (m *StrayManager) AddHand() {
+
+	hand := LittleHand{
+		Waiter: &m.Waiter,
+		Stray:  nil,
+	}
+
+	m.hands = append(m.hands, hand)
+}
+
+func (m *StrayManager) Start(count int) {
+	for i := 0; i < count; i++ {
+		m.AddHand()
+	}
+
+	for {
+		m.Waiter.Add(1)
+		for i := 0; i < len(m.hands); i++ {
+			if len(m.Strays) < i {
+				continue
+			}
+
+			m.hands[i].Stray = m.Strays[i]
+		}
+	}
+}

--- a/jprov/strays/types.go
+++ b/jprov/strays/types.go
@@ -1,0 +1,28 @@
+package strays
+
+import (
+	"sync"
+
+	"github.com/jackalLabs/canine-chain/x/storage/types"
+)
+
+type StrayQueue struct {
+}
+
+type StrayManager struct {
+	hands  []LittleHand
+	Waiter sync.WaitGroup
+	Strays []*types.Strays
+}
+
+func NewStrayManager() *StrayManager {
+	return &StrayManager{
+		hands:  []LittleHand{},
+		Strays: []*types.Strays{},
+	}
+}
+
+type LittleHand struct {
+	Stray  *types.Strays
+	Waiter *sync.WaitGroup
+}

--- a/jprov/utils/tx.go
+++ b/jprov/utils/tx.go
@@ -59,7 +59,7 @@ func SendTx(clientCtx client.Context, flagSet *pflag.FlagSet, msgs ...sdk.Msg) (
 	}
 
 	txf = txf.WithGas(uint64(2000000 * (len(msgs) + 1)))
-
+	txf.WithSequence(2)
 	if clientCtx.Simulate {
 		return nil, nil
 	}


### PR DESCRIPTION
Implementing a parallel queue with multiple addresses signing on behalf of the provider.

Strays being part of the queue were often causing the queue's transactions to fail, and since we were batch signing messages, it would force every proof in the transaction to fail as well, causing providers to miss proofs. To combat this we updated canine-chain to support a list of addresses that a provider can whitelist to claim strays on its behalf of. This allows us to claim strays in parallel with multiple signers all working for the commanding provider address.