### PR TITLE
Fix: SegFault & Txn Size cap

### DIFF
--- a/jprov/jprovd/provider_commands.go
+++ b/jprov/jprovd/provider_commands.go
@@ -40,6 +40,7 @@ func StartServerCommand() *cobra.Command {
 	cmd.Flags().Int(types.FlagMaxMisses, 16, "The amount of intervals a provider can miss their proofs before removing a file.")
 	cmd.Flags().Int64(types.FlagChunkSize, 10240, "The size of a single chunk.")
 	cmd.Flags().Int64(types.FlagStrayInterval, 10, "The interval in seconds to check for new strays.")
+	cmd.Flags().Int(types.FlagMessageSize, 20_000_000, "The max message size in bytes to submit to the chain at one time.")
 
 	return cmd
 }

--- a/jprov/queue/queue.go
+++ b/jprov/queue/queue.go
@@ -77,10 +77,12 @@ func (q *UploadQueue) listenOnce(cmd *cobra.Command) {
 		if err != nil {
 			v.Err = err
 		} else {
-			if res.Code != 0 {
-				v.Err = fmt.Errorf(res.RawLog)
-			} else {
-				v.Response = res
+			if res != nil {
+				if res.Code != 0 {
+					v.Err = fmt.Errorf(res.RawLog)
+				} else {
+					v.Response = res
+				}
 			}
 		}
 		if v.Callback != nil {

--- a/jprov/queue/queue.go
+++ b/jprov/queue/queue.go
@@ -41,6 +41,11 @@ func (q *UploadQueue) listenOnce(cmd *cobra.Command) {
 		return
 	}
 
+	maxSize, err := cmd.Flags().GetInt(types.FlagMessageSize)
+	if err != nil {
+		ctx.Logger.Error(err.Error())
+	}
+
 	msg := make([]ctypes.Msg, 0)
 	uploads := make([]*types.Upload, 0)
 	for i := 0; i < l; i++ {
@@ -54,7 +59,7 @@ func (q *UploadQueue) listenOnce(cmd *cobra.Command) {
 		uploadSize := len(upload.Message.String())
 
 		// if the size of the upload would put us past our cap, we cut off the queue and send only what fits
-		if msgSize+uploadSize > 20_000_000 {
+		if msgSize+uploadSize > maxSize {
 			l = i
 			break
 		}

--- a/jprov/queue/queue.go
+++ b/jprov/queue/queue.go
@@ -32,6 +32,10 @@ func (q *UploadQueue) listenOnce(cmd *cobra.Command) {
 	if q.Locked {
 		return
 	}
+	q.Locked = true
+	defer func() {
+		q.Locked = false
+	}()
 
 	ctx := utils.GetServerContextFromCmd(cmd)
 
@@ -74,6 +78,9 @@ func (q *UploadQueue) listenOnce(cmd *cobra.Command) {
 
 	res, err := utils.SendTx(clientCtx, cmd.Flags(), msg...)
 	for _, v := range uploads {
+		if v == nil {
+			continue
+		}
 		if err != nil {
 			v.Err = err
 		} else {

--- a/jprov/strays/hand_process.go
+++ b/jprov/strays/hand_process.go
@@ -44,6 +44,10 @@ func (h *LittleHand) Process(ctx *utils.Context, m *StrayManager) { // process t
 		return // There was an issue, so we pretend like it didn't happen.
 	}
 
+	if fileRes == nil {
+		return
+	}
+
 	var arr []string // Create an array of IPs from the request.
 	err = json.Unmarshal([]byte(fileRes.ProviderIps), &arr)
 	if err != nil {
@@ -105,13 +109,11 @@ func (h *LittleHand) Process(ctx *utils.Context, m *StrayManager) { // process t
 	res, err := h.SendTx(h.ClientContext, h.Cmd.Flags(), msg)
 	if err != nil {
 		ctx.Logger.Error(err.Error())
-		ctx.Logger.Error(res.RawLog)
 		return
 	}
 
 	if res == nil {
 		ctx.Logger.Error(err.Error())
-		ctx.Logger.Error(res.RawLog)
 		return
 	}
 

--- a/jprov/strays/hand_process.go
+++ b/jprov/strays/hand_process.go
@@ -113,7 +113,7 @@ func (h *LittleHand) Process(ctx *utils.Context, m *StrayManager) { // process t
 	}
 
 	if res == nil {
-		ctx.Logger.Error(err.Error())
+		ctx.Logger.Error("res is nil")
 		return
 	}
 

--- a/jprov/strays/hand_process.go
+++ b/jprov/strays/hand_process.go
@@ -118,6 +118,13 @@ func (h *LittleHand) Process(ctx *utils.Context, m *StrayManager) { // process t
 		return
 	}
 
+	if res == nil {
+		ctx.Logger.Error(err.Error())
+		ctx.Logger.Error(res.RawLog)
+		finish()
+		return
+	}
+
 	if res.Code != 0 {
 		ctx.Logger.Error(res.RawLog)
 		finish()

--- a/jprov/types/flags.go
+++ b/jprov/types/flags.go
@@ -6,4 +6,5 @@ const (
 	FlagMaxMisses     = "max-misses"
 	FlagChunkSize     = "chunk-size"
 	FlagStrayInterval = "stray-interval"
+	FlagMessageSize   = "max-msg-size"
 )


### PR DESCRIPTION
Handling some cases where the result may be null without throwing an error. 

Some Txns would be too big and cause a timeout on the RPC, this cap should avoid that.