### PR TITLE
fix: null pointer when withdraw txs fail

### DIFF
--- a/jprov/jprovd/client_commands.go
+++ b/jprov/jprovd/client_commands.go
@@ -71,7 +71,9 @@ func WithdrawCommand() *cobra.Command {
 			msg := banktypes.NewMsgSend(fromAddr, toAddr, coins)
 
 			res, err := utils.SendTx(clientCtx, cmd.Flags(), msg)
-			fmt.Println(res.RawLog)
+			if res != nil {
+				fmt.Println(res.RawLog)
+			}
 			return err
 		},
 	}

--- a/jprov/jprovd/client_commands.go
+++ b/jprov/jprovd/client_commands.go
@@ -70,7 +70,7 @@ func WithdrawCommand() *cobra.Command {
 
 			msg := banktypes.NewMsgSend(fromAddr, toAddr, coins)
 
-			res, err := utils.SendTx(clientCtx, cmd.Flags(), msg)
+			res, err := utils.SendTx(clientCtx, cmd.Flags(), "", msg)
 			if res != nil {
 				fmt.Println(res.RawLog)
 			}


### PR DESCRIPTION
Issue when withdrawing, sometimes null pointer faults.

![image](https://user-images.githubusercontent.com/34043723/228113346-ea1c292a-161f-4f6d-bc19-3d38f324592d.png)
