### PR TITLE
feat: Randomize stray selection

### DIFF
--- a/benchmark/bench.go
+++ b/benchmark/bench.go
@@ -34,5 +34,4 @@ func main() {
 	totalTime = totalTime / total
 
 	fmt.Printf("Took: %d microseconds on average.\n", totalTime)
-
 }

--- a/benchmark/bench.go
+++ b/benchmark/bench.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/wealdtech/go-merkletree/sha3"
+
+	"github.com/wealdtech/go-merkletree"
+)
+
+func main() {
+	rawTree, err := os.ReadFile("benchmark/tree.json")
+	if err != nil {
+		panic(err)
+	}
+
+	var total int64 = 5
+	var totalTime int64
+	var i int64
+	for ; i < total; i++ {
+		t := time.Now().UnixMicro()
+		for i := 0; i < 100; i++ {
+			_, err := merkletree.ImportMerkleTree(rawTree, sha3.New512())
+			if err != nil {
+				panic(err)
+			}
+		}
+		tt := time.Now().UnixMicro() - t
+		totalTime += tt
+		fmt.Printf("Took: %d microseconds.\n", tt)
+	}
+	totalTime = totalTime / total
+
+	fmt.Printf("Took: %d microseconds on average.\n", totalTime)
+
+}

--- a/go.mod
+++ b/go.mod
@@ -62,6 +62,7 @@ require (
 	github.com/go-kit/kit v0.12.0 // indirect
 	github.com/go-kit/log v0.2.1 // indirect
 	github.com/go-logfmt/logfmt v0.5.1 // indirect
+	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 // indirect
 	github.com/gogo/gateway v1.1.0 // indirect
 	github.com/gogo/protobuf v1.3.3 // indirect
@@ -88,10 +89,12 @@ require (
 	github.com/improbable-eng/grpc-web v0.15.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
 	github.com/jmhodges/levigo v1.0.0 // indirect
+	github.com/josharian/intern v1.0.0 // indirect
 	github.com/klauspost/compress v1.15.15 // indirect
 	github.com/lib/pq v1.10.6 // indirect
 	github.com/libp2p/go-buffer-pool v0.1.0 // indirect
 	github.com/magiconair/properties v1.8.6 // indirect
+	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.16 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
@@ -159,7 +162,7 @@ replace (
 	github.com/tendermint/tendermint => github.com/informalsystems/tendermint v0.34.23
 	github.com/tendermint/tm-db => github.com/informalsystems/tm-db v0.6.7
 
-	github.com/wealdtech/go-merkletree => github.com/TheMarstonConnell/go-merkletree v0.0.0-20230206055256-c9d693682156
+	github.com/wealdtech/go-merkletree => github.com/TheMarstonConnell/go-merkletree v0.0.0-20230328183338-b5d590ab1aaf
 	// use grpc compatible with cosmos-flavored protobufs
 	google.golang.org/grpc => google.golang.org/grpc v1.33.2
 

--- a/go.sum
+++ b/go.sum
@@ -90,8 +90,8 @@ github.com/Shopify/goreferrer v0.0.0-20220729165902-8cddb4f5de06/go.mod h1:7erjK
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
-github.com/TheMarstonConnell/go-merkletree v0.0.0-20230206055256-c9d693682156 h1:M1qn8MhTV2DxvWD6wMtYeHRr8D3ORUxdMM8UnNRPj20=
-github.com/TheMarstonConnell/go-merkletree v0.0.0-20230206055256-c9d693682156/go.mod h1:bM9mDSjsti+gkjl8FjovMoUH3MPR5bwJ3+ucaYFY0Jk=
+github.com/TheMarstonConnell/go-merkletree v0.0.0-20230328183338-b5d590ab1aaf h1:K8hLTtjPxDCIjb/YNncNWHTWDpubfPFbXWGE8vAQC4g=
+github.com/TheMarstonConnell/go-merkletree v0.0.0-20230328183338-b5d590ab1aaf/go.mod h1:Dpt5BLOsKmHAA6gAs3lyo9EKaLq2glBsEoHj3RqfN+Q=
 github.com/VictoriaMetrics/fastcache v1.6.0/go.mod h1:0qHz5QP0GMX4pfmMA/zt5RgfNuXJrTP0zS7DqpHGGTw=
 github.com/VividCortex/gohistogram v1.0.0 h1:6+hBz+qvs0JOrrNhhmR7lFxo5sINxBCGXrdtl/UvroE=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
@@ -426,8 +426,9 @@ github.com/gobwas/ws v1.0.2/go.mod h1:szmBTxLgaFppYjEmNtny/v3w89xOydFnnZMcgRRu/E
 github.com/gobwas/ws v1.1.0 h1:7RFti/xnNkMJnrK7D1yQ/iCIB5OrrY/54/H930kIbHA=
 github.com/gobwas/ws v1.1.0/go.mod h1:nzvNcVha5eUziGrbxFCo6qFIojQHjJV5cLYIbezhfL0=
 github.com/goccy/go-json v0.9.7/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
-github.com/goccy/go-json v0.9.11 h1:/pAaQDLHEoCq/5FFmSKBswWmK6H0e8g4159Kc/X/nqk=
 github.com/goccy/go-json v0.9.11/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
+github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=
+github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 h1:ZpnhV/YsD2/4cESfV5+Hoeu/iUR3ruzNvZ+yQfO03a0=
 github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2/go.mod h1:bBOAhwG1umN6/6ZUMtDFBMQR8jRg9O75tm9K00oMsK4=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
@@ -663,6 +664,7 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfC
 github.com/jmhodges/levigo v1.0.0 h1:q5EC36kV79HWeTBWsod3mG11EgStG3qArTKcvlksN1U=
 github.com/jmhodges/levigo v1.0.0/go.mod h1:Q6Qx+uH3RAqyK4rFQroq9RL7mdkABMcfhEI+nNuzMJQ=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
+github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/jrick/logrotate v1.0.0/go.mod h1:LNinyqDIJnpAur+b8yyulnQw/wDuN1+BYKlTRt3OuAQ=
@@ -767,6 +769,7 @@ github.com/magiconair/properties v1.8.6/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPK
 github.com/mailgun/raymond/v2 v2.0.46/go.mod h1:lsgvL50kgt1ylcFJYZiULi5fjPBkkhNfj4KA0W54Z18=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
+github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/matryer/moq v0.0.0-20190312154309-6cfb0558e1bd/go.mod h1:9ELz6aaclSIGnZBoaSLZ3NAl1VTufbOrXBPvtcy6WiQ=
 github.com/matryer/try v0.0.0-20161228173917-9ac251b645a2/go.mod h1:0KeJpeMD6o+O4hW7qJOT7vyQPKrWmj26uf5wMc/IiIs=

--- a/jprov/jprovd/client_commands.go
+++ b/jprov/jprovd/client_commands.go
@@ -70,7 +70,7 @@ func WithdrawCommand() *cobra.Command {
 
 			msg := banktypes.NewMsgSend(fromAddr, toAddr, coins)
 
-			res, err := utils.SendTx(clientCtx, cmd.Flags(), msg)
+			res, err := utils.SendTx(clientCtx, cmd.Flags(), "", msg)
 			fmt.Println(res.RawLog)
 			return err
 		},

--- a/jprov/jprovd/init_provider.go
+++ b/jprov/jprovd/init_provider.go
@@ -43,7 +43,7 @@ func CmdInitProvider() *cobra.Command {
 				fmt.Println(err)
 				return err
 			}
-			res, err := utils.SendTx(clientCtx, cmd.Flags(), msg)
+			res, err := utils.SendTx(clientCtx, cmd.Flags(), "", msg)
 			if err != nil {
 				fmt.Println(err)
 				return err

--- a/jprov/jprovd/provider_commands.go
+++ b/jprov/jprovd/provider_commands.go
@@ -43,7 +43,7 @@ func StartServerCommand() *cobra.Command {
 	cmd.Flags().Int(types.FlagGasCap, 20_000, "The maximum gas to be used per message.")
 	cmd.Flags().Int(types.FlagMaxFileSize, 32000, "The maximum size allowed to be sent to this provider in mbs. (only for monitoring services)")
 	cmd.Flags().Int64(types.FlagQueueInterval, 2, "The time, in seconds, between running a queue loop.")
-
+	cmd.Flags().String(types.FlagProviderName, "A Storage Provider", "The name to identify this provider in block explorers.")
 	return cmd
 }
 

--- a/jprov/jprovd/set_provider_ip.go
+++ b/jprov/jprovd/set_provider_ip.go
@@ -36,7 +36,7 @@ func CmdSetProviderIP() *cobra.Command {
 			if err := msg.ValidateBasic(); err != nil {
 				return err
 			}
-			_, err = utils.SendTx(clientCtx, cmd.Flags(), msg)
+			_, err = utils.SendTx(clientCtx, cmd.Flags(), "", msg)
 			return err
 		},
 	}

--- a/jprov/jprovd/set_provider_keybase.go
+++ b/jprov/jprovd/set_provider_keybase.go
@@ -38,7 +38,7 @@ func CmdSetProviderKeybase() *cobra.Command {
 				return err
 			}
 
-			_, err = utils.SendTx(clientCtx, cmd.Flags(), msg)
+			_, err = utils.SendTx(clientCtx, cmd.Flags(), "", msg)
 			return err
 		},
 	}

--- a/jprov/jprovd/set_provider_totalspace.go
+++ b/jprov/jprovd/set_provider_totalspace.go
@@ -37,7 +37,7 @@ func CmdSetProviderTotalspace() *cobra.Command {
 			if err := msg.ValidateBasic(); err != nil {
 				return err
 			}
-			_, err = utils.SendTx(clientCtx, cmd.Flags(), msg)
+			_, err = utils.SendTx(clientCtx, cmd.Flags(), "", msg)
 			return err
 		},
 	}

--- a/jprov/queue/queue.go
+++ b/jprov/queue/queue.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/JackalLabs/jackal-provider/jprov/testutils"
 	"github.com/JackalLabs/jackal-provider/jprov/types"
 	"github.com/JackalLabs/jackal-provider/jprov/utils"
 
@@ -58,11 +57,6 @@ func (q *UploadQueue) listenOnce(cmd *cobra.Command, providerName string) {
 		ctx.Logger.Error(err.Error())
 	}
 
-	logger, logFile := testutils.CreateLogger("cutTheQueue")
-	logger.Println("===============BROADCASTING NEW BATCH====================")
-
-	logger.Printf("length of queue is : %d\n", l)
-
 	var totalSizeOfMsgs int
 	msgs := make([]cosmosTypes.Msg, 0)
 	uploads := make([]*types.Upload, 0)
@@ -72,14 +66,11 @@ func (q *UploadQueue) listenOnce(cmd *cobra.Command, providerName string) {
 		upload := q.Queue[i]
 
 		uploadSize := len(upload.Message.String())
-		logger.Printf("totalSizeOfMsgs is now : %d --getting bigger?\n", totalSizeOfMsgs)
 
 		// if the size of the upload would put us past our cap, we cut off the queue and send only what fits
 		if totalSizeOfMsgs+uploadSize > maxSize {
-			logger.Printf("totalSizeOfMsgs+uploadSize is : %d, which is bigger than %d\n", totalSizeOfMsgs+uploadSize, maxSize)
 			msgs = msgs[:len(msgs)-1]
 			uploads = uploads[:len(uploads)-1]
-			logger.Printf("length of msgs array--last element popped--is now : %d\n", len(msgs))
 			l = i
 
 			break
@@ -87,19 +78,13 @@ func (q *UploadQueue) listenOnce(cmd *cobra.Command, providerName string) {
 			uploads = append(uploads, upload)
 			msgs = append(msgs, upload.Message)
 			totalSizeOfMsgs += len(upload.Message.String())
-			logger.Printf("length of msgs array is now : %d\n", len(msgs))
 		}
 
 	}
 
 	clientCtx := client.GetClientContextFromCmd(cmd)
 
-	logger.Printf("len(msgs) right before being broadcast? : %d\n", len(msgs))
-	err = logFile.Close()
-	if err != nil {
-		fmt.Println(err)
-	}
-	res, err := utils.SendTx(clientCtx, cmd.Flags(), fmt.Sprintf("Storage Provided by %s.", providerName), msgs...)
+	res, err := utils.SendTx(clientCtx, cmd.Flags(), fmt.Sprintf("Storage Provided by %s", providerName), msgs...)
 	for _, v := range uploads {
 		if v == nil {
 			continue

--- a/jprov/queue/queue.go
+++ b/jprov/queue/queue.go
@@ -36,7 +36,7 @@ func (q *UploadQueue) Append(upload *types.Upload) {
 	q.Queue = append(q.Queue, upload)
 }
 
-func (q *UploadQueue) listenOnce(cmd *cobra.Command) {
+func (q *UploadQueue) listenOnce(cmd *cobra.Command, providerName string) {
 	if q.Locked {
 		return
 	}
@@ -99,7 +99,7 @@ func (q *UploadQueue) listenOnce(cmd *cobra.Command) {
 	if err != nil {
 		fmt.Println(err)
 	}
-	res, err := utils.SendTx(clientCtx, cmd.Flags(), msgs...)
+	res, err := utils.SendTx(clientCtx, cmd.Flags(), fmt.Sprintf("Storage Provided by %s.", providerName), msgs...)
 	for _, v := range uploads {
 		if v == nil {
 			continue
@@ -123,7 +123,7 @@ func (q *UploadQueue) listenOnce(cmd *cobra.Command) {
 	q.Queue = q.Queue[l:] // pop every upload that fit off the queue
 }
 
-func (q *UploadQueue) StartListener(cmd *cobra.Command) {
+func (q *UploadQueue) StartListener(cmd *cobra.Command, providerName string) {
 	for {
 		interval, err := cmd.Flags().GetInt64(types.FlagQueueInterval)
 		if err != nil {
@@ -131,6 +131,6 @@ func (q *UploadQueue) StartListener(cmd *cobra.Command) {
 		}
 		time.Sleep(time.Second * time.Duration(interval))
 
-		q.listenOnce(cmd)
+		q.listenOnce(cmd, providerName)
 	}
 }

--- a/jprov/server/file_server.go
+++ b/jprov/server/file_server.go
@@ -196,6 +196,11 @@ func StartFileServer(cmd *cobra.Command) {
 		return
 	}
 
+	providerName, err := cmd.Flags().GetString(types.FlagProviderName)
+	if err != nil {
+		providerName = "A Storage Provider"
+	}
+
 	manager := strays.NewStrayManager(cmd) // creating and starting the stray management system
 	if !strs {
 		manager.Init(cmd, threads, db)
@@ -203,7 +208,7 @@ func StartFileServer(cmd *cobra.Command) {
 
 	go postProofs(cmd, db, &q, ctx)
 	go NatCycle(cmd.Context())
-	go q.StartListener(cmd)
+	go q.StartListener(cmd, providerName)
 
 	if !strs {
 		go manager.Start(cmd)

--- a/jprov/strays/hand_process.go
+++ b/jprov/strays/hand_process.go
@@ -14,6 +14,7 @@ import (
 	txns "github.com/cosmos/cosmos-sdk/client/tx"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/query"
 	"github.com/cosmos/cosmos-sdk/types/tx/signing"
 	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
 	storageTypes "github.com/jackalLabs/canine-chain/x/storage/types"
@@ -314,7 +315,19 @@ func (m *StrayManager) CollectStrays(cmd *cobra.Command) {
 	m.Context.Logger.Info("Collecting strays from chain...")
 	qClient := storageTypes.NewQueryClient(m.ClientContext)
 
-	res, err := qClient.StraysAll(cmd.Context(), &storageTypes.QueryAllStraysRequest{})
+	reverse := rand.Intn(2) == 0
+
+	max := uint64(len(m.hands))
+	if max > 50 {
+		max = 50
+	}
+
+	pagination := &query.PageRequest{
+		Limit:   max,
+		Reverse: reverse,
+	}
+
+	res, err := qClient.StraysAll(cmd.Context(), &storageTypes.QueryAllStraysRequest{Pagination: pagination})
 	if err != nil {
 		m.Context.Logger.Error(err.Error())
 		return

--- a/jprov/strays/hand_process.go
+++ b/jprov/strays/hand_process.go
@@ -4,7 +4,9 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"math/rand"
 	"os"
+	"time"
 
 	"github.com/JackalLabs/jackal-provider/jprov/crypto"
 	"github.com/JackalLabs/jackal-provider/jprov/utils"
@@ -325,26 +327,13 @@ func (m *StrayManager) CollectStrays(cmd *cobra.Command) {
 		return
 	}
 
+	rand.Seed(time.Now().UnixNano())
+	rand.Shuffle(len(s), func(i, j int) { s[i], s[j] = s[j], s[i] })
+
 	for _, newStray := range s { // Only add new strays to the queue
-		m.Context.Logger.Info(fmt.Sprintf("Ingress of %s...", newStray.Cid))
-		clean := true
-		for _, oldStray := range m.Strays {
-			if newStray.Cid == oldStray.Cid {
-				clean = false
-			}
-		}
-		for _, hands := range m.hands { // check active processes too
-			if hands.Stray == nil {
-				continue
-			}
-			if newStray.Cid == hands.Stray.Cid {
-				clean = false
-			}
-		}
-		if clean {
-			m.Context.Logger.Info(fmt.Sprintf("Got metadata for %s", newStray.Cid))
-			k := newStray
-			m.Strays = append(m.Strays, &k)
-		}
+
+		k := newStray
+		m.Strays = append(m.Strays, &k)
+
 	}
 }

--- a/jprov/strays/hand_process.go
+++ b/jprov/strays/hand_process.go
@@ -14,7 +14,6 @@ import (
 	txns "github.com/cosmos/cosmos-sdk/client/tx"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/types/query"
 	"github.com/cosmos/cosmos-sdk/types/tx/signing"
 	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
 	storageTypes "github.com/jackalLabs/canine-chain/x/storage/types"
@@ -315,19 +314,7 @@ func (m *StrayManager) CollectStrays(cmd *cobra.Command) {
 	m.Context.Logger.Info("Collecting strays from chain...")
 	qClient := storageTypes.NewQueryClient(m.ClientContext)
 
-	reverse := rand.Intn(2) == 0
-
-	max := uint64(len(m.hands))
-	if max > 50 {
-		max = 50
-	}
-
-	pagination := &query.PageRequest{
-		Limit:   max,
-		Reverse: reverse,
-	}
-
-	res, err := qClient.StraysAll(cmd.Context(), &storageTypes.QueryAllStraysRequest{Pagination: pagination})
+	res, err := qClient.StraysAll(cmd.Context(), &storageTypes.QueryAllStraysRequest{})
 	if err != nil {
 		m.Context.Logger.Error(err.Error())
 		return

--- a/jprov/strays/stray_manager.go
+++ b/jprov/strays/stray_manager.go
@@ -109,7 +109,7 @@ func (m *StrayManager) Init(cmd *cobra.Command, count uint, db *leveldb.DB) { //
 
 		msg := storageTypes.NewMsgAddClaimer(address, h.Address)
 
-		res, err := utils.SendTx(clientCtx, cmd.Flags(), msg)
+		res, err := utils.SendTx(clientCtx, cmd.Flags(), "", msg)
 		if err != nil {
 			fmt.Println(err)
 			continue
@@ -146,7 +146,7 @@ func (m *StrayManager) Init(cmd *cobra.Command, count uint, db *leveldb.DB) { //
 			continue
 		}
 
-		grantRes, nerr := utils.SendTx(clientCtx, cmd.Flags(), grantMsg)
+		grantRes, nerr := utils.SendTx(clientCtx, cmd.Flags(), "", grantMsg)
 		if nerr != nil {
 			fmt.Println(nerr)
 			continue

--- a/jprov/types/flags.go
+++ b/jprov/types/flags.go
@@ -11,4 +11,5 @@ const (
 	FlagGasCap        = "gas-cap"
 	FlagMaxFileSize   = "max-file-size"
 	FlagQueueInterval = "queue-interval"
+	FlagProviderName  = "moniker"
 )

--- a/jprov/utils/tx.go
+++ b/jprov/utils/tx.go
@@ -49,7 +49,7 @@ func prepareFactory(clientCtx client.Context, txf txns.Factory) (txns.Factory, e
 	return txf, nil
 }
 
-func SendTx(clientCtx client.Context, flagSet *pflag.FlagSet, msgs ...sdk.Msg) (*sdk.TxResponse, error) {
+func SendTx(clientCtx client.Context, flagSet *pflag.FlagSet, memo string, msgs ...sdk.Msg) (*sdk.TxResponse, error) {
 	txf := txns.NewFactoryCLI(clientCtx, flagSet)
 
 	txf, err := prepareFactory(clientCtx, txf)
@@ -86,6 +86,8 @@ func SendTx(clientCtx client.Context, flagSet *pflag.FlagSet, msgs ...sdk.Msg) (
 	if err != nil {
 		return nil, err
 	}
+
+	tx.SetMemo(memo)
 
 	txBytes, err := clientCtx.TxConfig.TxEncoder()(tx.GetTx())
 	if err != nil {

--- a/jprov/utils/tx.go
+++ b/jprov/utils/tx.go
@@ -82,12 +82,12 @@ func SendTx(clientCtx client.Context, flagSet *pflag.FlagSet, memo string, msgs 
 	}
 
 	tx.SetFeeGranter(clientCtx.GetFeeGranterAddress())
+	tx.SetMemo(memo)
+
 	err = Sign(txf, clientCtx, tx, true)
 	if err != nil {
 		return nil, err
 	}
-
-	tx.SetMemo(memo)
 
 	txBytes, err := clientCtx.TxConfig.TxEncoder()(tx.GetTx())
 	if err != nil {


### PR DESCRIPTION
Debating this be an option, I want providers to maintain control of their machines to the fullest, but this prevents machines from racing after the same strays which makes it better for the protocol and oftentimes the providers themselves. I think eventually, some providers would benefit from attempting to claim big files over small files, so having a few different "stray operation modes" could be really good for future-proofing. Let me know what you think.

@karnthis @BiPhan4 