### PR TITLE
tweak: adjusting provider timings

### DIFF
--- a/jprov/jprovd/provider_commands.go
+++ b/jprov/jprovd/provider_commands.go
@@ -34,15 +34,15 @@ func StartServerCommand() *cobra.Command {
 	cmd.Flags().Int(types.FlagPort, 3333, "Port to host the server on.")
 	cmd.Flags().String(types.VersionFlag, "", "The value exposed by the version api to allow for custom deployments.")
 	cmd.Flags().Bool(types.HaltStraysFlag, false, "Debug flag to stop picking up strays.")
-	cmd.Flags().Uint16(types.FlagInterval, 10, "The interval in seconds for which to check proofs.")
+	cmd.Flags().Uint16(types.FlagInterval, 32, "The interval in seconds for which to check proofs.")
 	cmd.Flags().Uint(types.FlagThreads, 10, "The amount of stray threads.")
 	cmd.Flags().Int(types.FlagMaxMisses, 16, "The amount of intervals a provider can miss their proofs before removing a file.")
 	cmd.Flags().Int64(types.FlagChunkSize, 10240, "The size of a single chunk.")
-	cmd.Flags().Int64(types.FlagStrayInterval, 10, "The interval in seconds to check for new strays.")
+	cmd.Flags().Int64(types.FlagStrayInterval, 20, "The interval in seconds to check for new strays.")
 	cmd.Flags().Int(types.FlagMessageSize, 500_000, "The max message size in bytes to submit to the chain at one time.")
 	cmd.Flags().Int(types.FlagGasCap, 20_000, "The maximum gas to be used per message.")
 	cmd.Flags().Int(types.FlagMaxFileSize, 32000, "The maximum size allowed to be sent to this provider in mbs. (only for monitoring services)")
-	cmd.Flags().Int64(types.FlagQueueInterval, 2, "The time, in seconds, between running a queue loop.")
+	cmd.Flags().Int64(types.FlagQueueInterval, 4, "The time, in seconds, between running a queue loop.")
 
 	return cmd
 }


### PR DESCRIPTION
Changing some default params so standard nodes will be less likely to all slam proofs into a single block space. This will most likely need changed again when we move the goalposts on the proving window.