### PR TITLE
fix: Providers not claiming strays they don't have

### DIFF
--- a/jprov/server/proofs.go
+++ b/jprov/server/proofs.go
@@ -236,17 +236,19 @@ func postProofs(cmd *cobra.Command, db *leveldb.DB, q *queue.UploadQueue, ctx *u
 						if err != nil {
 							ctx.Logger.Error(err.Error())
 						}
+
+						err = os.Remove(utils.GetStoragePathForTree(clientCtx, fid))
+						if err != nil {
+							ctx.Logger.Error(err.Error())
+							continue
+						}
 					}
 					err = db.Delete(utils.MakeFileKey(cid), nil)
 					if err != nil {
 						ctx.Logger.Error(err.Error())
 						continue
 					}
-					err = os.Remove(utils.GetStoragePathForTree(clientCtx, fid))
-					if err != nil {
-						ctx.Logger.Error(err.Error())
-						continue
-					}
+
 					err = db.Delete(utils.MakeDowntimeKey(cid), nil)
 					if err != nil {
 						ctx.Logger.Error(err.Error())

--- a/jprov/server/proofs.go
+++ b/jprov/server/proofs.go
@@ -180,7 +180,6 @@ func postProofs(cmd *cobra.Command, db *leveldb.DB, q *queue.UploadQueue, ctx *u
 			if cid[:len(utils.FileKey)] != utils.FileKey {
 				continue
 			}
-			fid := value
 
 			cid = cid[len(utils.FileKey):]
 
@@ -227,7 +226,7 @@ func postProofs(cmd *cobra.Command, db *leveldb.DB, q *queue.UploadQueue, ctx *u
 							break
 						}
 					}
-					ctx.Logger.Info(fmt.Sprintf("%s is being removed", value))
+					ctx.Logger.Info(fmt.Sprintf("%s is being removed", cid))
 
 					if !duplicate {
 						ctx.Logger.Info("And we are removing the file on disk.")
@@ -237,7 +236,7 @@ func postProofs(cmd *cobra.Command, db *leveldb.DB, q *queue.UploadQueue, ctx *u
 							ctx.Logger.Error(err.Error())
 						}
 
-						err = os.Remove(utils.GetStoragePathForTree(clientCtx, fid))
+						err = os.Remove(utils.GetStoragePathForTree(clientCtx, value))
 						if err != nil {
 							ctx.Logger.Error(err.Error())
 							continue

--- a/jprov/server/proofs.go
+++ b/jprov/server/proofs.go
@@ -168,28 +168,10 @@ func postProofs(cmd *cobra.Command, db *leveldb.DB, q *queue.UploadQueue, ctx *u
 		return
 	}
 
-	//type IterWrap struct {
-	//	Key   []byte
-	//	Value []byte
-	//}
-
 	for {
 		start := time.Now()
-		// ctx.Logger.Info(fmt.Sprintf("Starting proof commitment at %s", start.Format("2006-01-02 15:04:05.000000")))
-		// m := []IterWrap{}
+
 		iter := db.NewIterator(nil, nil)
-		//for iter.Next() {
-		//	mm := IterWrap{
-		//		Key:   iter.Key(),
-		//		Value: iter.Value(),
-		//	}
-		//	m = append(m, mm)
-		//}
-		//iter.Release()
-		//err = iter.Error()
-		//if err != nil {
-		//	ctx.Logger.Error("Iterator Error: %s", err.Error())
-		//}
 
 		for iter.Next() {
 			cid := string(iter.Key())

--- a/jprov/strays/hand_process.go
+++ b/jprov/strays/hand_process.go
@@ -68,9 +68,11 @@ func (h *LittleHand) Process(ctx *utils.Context, m *StrayManager) { // process t
 			return // If we don't have it and nobody else does, there is nothing we can do.
 		}
 	} else { // If there are providers with this file, we will download it from them instead to keep things consistent
-		if _, err := os.Stat(utils.GetStoragePath(h.ClientContext, h.Stray.Fid)); !os.IsNotExist(err) {
-			ctx.Logger.Info("Already have this file")
-			return
+
+		for _, prov := range arr {
+			if prov == m.Ip { // Ignore ourselves
+				return
+			}
 		}
 
 		found := false
@@ -78,9 +80,7 @@ func (h *LittleHand) Process(ctx *utils.Context, m *StrayManager) { // process t
 			if found {
 				continue
 			}
-			if prov == m.Ip { // Ignore ourselves
-				return
-			}
+
 			_, err = utils.DownloadFileFromURL(h.Cmd, prov, h.Stray.Fid, h.Stray.Cid, h.Database, ctx.Logger)
 			if err != nil {
 				ctx.Logger.Error(err.Error())


### PR DESCRIPTION
There seems to be a bug where providers aren't deleting files they lost due to downtime. Because of this, the hands wouldn't try to claim strays that were already on disk, I removed this as a bandage fix until we figure out why they are not removing dead files.