### PR TITLE
sleep for 1 second before adding another proof to queue

### DIFF
--- a/jprov/jprovd/provider_commands.go
+++ b/jprov/jprovd/provider_commands.go
@@ -44,6 +44,7 @@ func StartServerCommand() *cobra.Command {
 	cmd.Flags().Int(types.FlagMaxFileSize, 32000, "The maximum size allowed to be sent to this provider in mbs. (only for monitoring services)")
 	cmd.Flags().Int64(types.FlagQueueInterval, 4, "The time, in seconds, between running a queue loop.")
 	cmd.Flags().String(types.FlagProviderName, "A Storage Provider", "The name to identify this provider in block explorers.")
+	cmd.Flags().Int64(types.FlagSleep, 250, "The time, in milliseconds, before adding another proof msg to the queue.")
 	return cmd
 }
 

--- a/jprov/queue/queue.go
+++ b/jprov/queue/queue.go
@@ -83,6 +83,7 @@ func (q *UploadQueue) listenOnce(cmd *cobra.Command, providerName string) {
 	}
 
 	clientCtx := client.GetClientContextFromCmd(cmd)
+	ctx.Logger.Info(fmt.Sprintf("TOTAL no. of msgs in proof transaction is: %d", len(msgs)))
 
 	res, err := utils.SendTx(clientCtx, cmd.Flags(), fmt.Sprintf("Storage Provided by %s", providerName), msgs...)
 	for _, v := range uploads {
@@ -104,7 +105,6 @@ func (q *UploadQueue) listenOnce(cmd *cobra.Command, providerName string) {
 			v.Callback.Done()
 		}
 	}
-	ctx.Logger.Info(fmt.Sprintf("TOTAL no. of msgs in proof transaction is: %d", len(msgs)))
 
 	q.Queue = q.Queue[l:] // pop every upload that fit off the queue
 }

--- a/jprov/queue/queue.go
+++ b/jprov/queue/queue.go
@@ -104,6 +104,7 @@ func (q *UploadQueue) listenOnce(cmd *cobra.Command, providerName string) {
 			v.Callback.Done()
 		}
 	}
+	ctx.Logger.Info(fmt.Sprintf("TOTAL no. of msgs in proof transaction is: %d", len(msgs)))
 
 	q.Queue = q.Queue[l:] // pop every upload that fit off the queue
 }

--- a/jprov/queue/queue.go
+++ b/jprov/queue/queue.go
@@ -83,7 +83,7 @@ func (q *UploadQueue) listenOnce(cmd *cobra.Command, providerName string) {
 	}
 
 	clientCtx := client.GetClientContextFromCmd(cmd)
-	ctx.Logger.Info(fmt.Sprintf("TOTAL no. of msgs in proof transaction is: %d", len(msgs)))
+	ctx.Logger.Debug(fmt.Sprintf("total no. of msgs in proof transaction is: %d", len(msgs)))
 
 	res, err := utils.SendTx(clientCtx, cmd.Flags(), fmt.Sprintf("Storage Provided by %s", providerName), msgs...)
 	for _, v := range uploads {

--- a/jprov/server/proofs.go
+++ b/jprov/server/proofs.go
@@ -310,7 +310,7 @@ func postProofs(cmd *cobra.Command, db *leveldb.DB, q *queue.UploadQueue, ctx *u
 				ctx.Logger.Error(fmt.Sprintf("Posting Proof Error: %v", err))
 				continue
 			}
-			sleep, err := cmd.Flags().GetInt16(types.FlagSleep)
+			sleep, err := cmd.Flags().GetInt64(types.FlagSleep)
 			if err != nil {
 				ctx.Logger.Error(err.Error())
 				return

--- a/jprov/server/proofs.go
+++ b/jprov/server/proofs.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"math/rand"
 	"os"
 	"strconv"
 	"strings"
@@ -172,12 +171,12 @@ func postProofs(cmd *cobra.Command, db *leveldb.DB, q *queue.UploadQueue, ctx *u
 	for {
 		interval := intervalFromCMD
 
-		if interval < 1800 { // If the provider picked an interval that's less than 30 minutes, we generate a random interval for them anyways
+		// if interval < 1800 { // If the provider picked an interval that's less than 30 minutes, we generate a random interval for them anyways
 
-			r := rand.New(rand.NewSource(time.Now().UnixNano()))
-			interval = uint16(r.Intn(901) + 900) // Generate interval between 15-30 minutes
+		// 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+		// 	interval = uint16(r.Intn(901) + 900) // Generate interval between 15-30 minutes
 
-		}
+		// }
 		ctx.Logger.Debug(fmt.Sprintf("The interval between proofs is now %d", interval))
 		start := time.Now()
 

--- a/jprov/server/proofs.go
+++ b/jprov/server/proofs.go
@@ -309,7 +309,7 @@ func postProofs(cmd *cobra.Command, db *leveldb.DB, q *queue.UploadQueue, ctx *u
 				ctx.Logger.Error(fmt.Sprintf("Posting Proof Error: %v", err))
 				continue
 			}
-			time.Sleep(333 * time.Millisecond)
+			time.Sleep(250 * time.Millisecond)
 
 		}
 

--- a/jprov/server/proofs.go
+++ b/jprov/server/proofs.go
@@ -309,7 +309,7 @@ func postProofs(cmd *cobra.Command, db *leveldb.DB, q *queue.UploadQueue, ctx *u
 				ctx.Logger.Error(fmt.Sprintf("Posting Proof Error: %v", err))
 				continue
 			}
-			// time.Sleep(time.Second) // remove the sleep after posting proof
+			time.Sleep(333 * time.Millisecond)
 
 		}
 

--- a/jprov/server/proofs.go
+++ b/jprov/server/proofs.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math/rand"
 	"os"
 	"strconv"
 	"strings"
@@ -171,12 +172,12 @@ func postProofs(cmd *cobra.Command, db *leveldb.DB, q *queue.UploadQueue, ctx *u
 	for {
 		interval := intervalFromCMD
 
-		// if interval < 1800 { // If the provider picked an interval that's less than 30 minutes, we generate a random interval for them anyways
+		if interval < 1800 { // If the provider picked an interval that's less than 30 minutes, we generate a random interval for them anyways
 
-		// 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
-		// 	interval = uint16(r.Intn(901) + 900) // Generate interval between 15-30 minutes
+			r := rand.New(rand.NewSource(time.Now().UnixNano()))
+			interval = uint16(r.Intn(901) + 900) // Generate interval between 15-30 minutes
 
-		// }
+		}
 		ctx.Logger.Debug(fmt.Sprintf("The interval between proofs is now %d", interval))
 		start := time.Now()
 
@@ -309,7 +310,12 @@ func postProofs(cmd *cobra.Command, db *leveldb.DB, q *queue.UploadQueue, ctx *u
 				ctx.Logger.Error(fmt.Sprintf("Posting Proof Error: %v", err))
 				continue
 			}
-			time.Sleep(250 * time.Millisecond)
+			sleep, err := cmd.Flags().GetInt16(types.FlagSleep)
+			if err != nil {
+				ctx.Logger.Error(err.Error())
+				return
+			}
+			time.Sleep(time.Duration(sleep) * time.Millisecond)
 
 		}
 

--- a/jprov/server/proofs.go
+++ b/jprov/server/proofs.go
@@ -309,7 +309,7 @@ func postProofs(cmd *cobra.Command, db *leveldb.DB, q *queue.UploadQueue, ctx *u
 				ctx.Logger.Error(fmt.Sprintf("Posting Proof Error: %v", err))
 				continue
 			}
-			time.Sleep(time.Second)
+			// time.Sleep(time.Second) // remove the sleep after posting proof
 
 		}
 

--- a/jprov/server/proofs.go
+++ b/jprov/server/proofs.go
@@ -310,6 +310,7 @@ func postProofs(cmd *cobra.Command, db *leveldb.DB, q *queue.UploadQueue, ctx *u
 				ctx.Logger.Error(fmt.Sprintf("Posting Proof Error: %v", err))
 				continue
 			}
+			time.Sleep(time.Second)
 
 		}
 

--- a/jprov/types/flags.go
+++ b/jprov/types/flags.go
@@ -12,4 +12,5 @@ const (
 	FlagMaxFileSize   = "max-file-size"
 	FlagQueueInterval = "queue-interval"
 	FlagProviderName  = "moniker"
+	FlagSleep         = "sleep"
 )


### PR DESCRIPTION
I updated my personal provider to use main as at latest commit--interval improvement. Timeout errors still occur, although much more spread out in time. 

Per source code, a tendermint node will wait 10 seconds before removing a transaction from its mempool and returning the time out error. 

Even though we are spreading out the periods during which our proofs are committed, we are still overloading our tendermint nodes while we are committing proofs.

I opine this is the current problematic chain of events:

1. postProofs() can add proof msgs to the queue very fast, so much so that when listenOnce() is called, there is a possibility that the queue has 50+ proof msgs--which is very likely if a provider has many files.
2. Based on our default 'max-msg-size', the maximum number of msgs per transaction is around 25-28. 
3. We broadcast tx(28*msgs), sleep for 2 seconds and immediately broadcast another tx(28*msgs), and so on.
4. The second, or even third transaction, is timing out before being committed to a block.

Solution:

We can't sleep between broadcasting transactions, because this would cause delays between 'postContract()', making the file upload process even longer.

We can slow the rate at which proof messages are added to the queue, so that multiple large txs, each containing 28 msgs each, are not being sent to the mempool 2 seconds apart.  


