### PR TITLE
API: chain-id in the version response

### DIFF
--- a/jprov/server/http.go
+++ b/jprov/server/http.go
@@ -54,12 +54,13 @@ func checkVersion(cmd *cobra.Command, w http.ResponseWriter, ctx *utils.Context)
 	}
 
 	clientContext := client.GetClientContextFromCmd(cmd)
+	chainID := clientContext.ChainID
 
 	var v types.VersionResponse
 	if len(res) > 0 {
 		v = types.VersionResponse{
 			Version: res,
-			ChainID: clientContext.ChainID,
+			ChainID: chainID,
 		}
 	} else {
 		v = types.VersionResponse{

--- a/jprov/server/http.go
+++ b/jprov/server/http.go
@@ -53,10 +53,13 @@ func checkVersion(cmd *cobra.Command, w http.ResponseWriter, ctx *utils.Context)
 		ctx.Logger.Error(err.Error())
 	}
 
+	clientContext := client.GetClientContextFromCmd(cmd)
+
 	var v types.VersionResponse
 	if len(res) > 0 {
 		v = types.VersionResponse{
 			Version: res,
+			ChainID: clientContext.ChainID,
 		}
 	} else {
 		v = types.VersionResponse{

--- a/jprov/server/http.go
+++ b/jprov/server/http.go
@@ -53,7 +53,11 @@ func checkVersion(cmd *cobra.Command, w http.ResponseWriter, ctx *utils.Context)
 		ctx.Logger.Error(err.Error())
 	}
 
-	clientCtx, err := client.GetClientTxContext(cmd)
+	clientCtx, error := client.GetClientTxContext(cmd)
+	if error != nil {
+		ctx.Logger.Error(err.Error())
+		return
+	}
 	chainID := clientCtx.ChainID
 
 	var v types.VersionResponse

--- a/jprov/server/http.go
+++ b/jprov/server/http.go
@@ -53,18 +53,18 @@ func checkVersion(cmd *cobra.Command, w http.ResponseWriter, ctx *utils.Context)
 		ctx.Logger.Error(err.Error())
 	}
 
-	clientCtx, error := client.GetClientTxContext(cmd)
-	if error != nil {
-		ctx.Logger.Error(err.Error())
-		return
-	}
-	chainID := clientCtx.ChainID
+	// clientCtx, error := client.GetClientTxContext(cmd)
+	// if error != nil {
+	// 	ctx.Logger.Error(err.Error())
+	// 	return
+	// }
+	// chainID := clientCtx.ChainID
 
 	var v types.VersionResponse
 	if len(res) > 0 {
 		v = types.VersionResponse{
 			Version: res,
-			ChainID: chainID,
+			ChainID: "test-chain",
 		}
 	} else {
 		v = types.VersionResponse{

--- a/jprov/server/http.go
+++ b/jprov/server/http.go
@@ -54,12 +54,13 @@ func checkVersion(cmd *cobra.Command, w http.ResponseWriter, ctx *utils.Context)
 	}
 
 	clientCtx, err := client.GetClientTxContext(cmd)
+	chainID := clientCtx.ChainID
 
 	var v types.VersionResponse
 	if len(res) > 0 {
 		v = types.VersionResponse{
 			Version: res,
-			ChainID: clientCtx.ChainID,
+			ChainID: chainID,
 		}
 	} else {
 		v = types.VersionResponse{

--- a/jprov/server/http.go
+++ b/jprov/server/http.go
@@ -60,17 +60,12 @@ func checkVersion(cmd *cobra.Command, w http.ResponseWriter, ctx *utils.Context)
 	}
 	chainID := clientCtx.ChainID
 
-	var v types.VersionResponse
+	v := types.VersionResponse{
+		Version: version.Version,
+		ChainID: chainID,
+	}
 	if len(res) > 0 {
-		v = types.VersionResponse{
-			Version: res,
-			ChainID: chainID,
-		}
-	} else {
-		v = types.VersionResponse{
-			Version: version.Version,
-			ChainID: chainID,
-		}
+		v.Version = res
 	}
 
 	err = json.NewEncoder(w).Encode(v)

--- a/jprov/server/http.go
+++ b/jprov/server/http.go
@@ -53,23 +53,23 @@ func checkVersion(cmd *cobra.Command, w http.ResponseWriter, ctx *utils.Context)
 		ctx.Logger.Error(err.Error())
 	}
 
-	// clientCtx, error := client.GetClientTxContext(cmd)
-	// if error != nil {
-	// 	ctx.Logger.Error(err.Error())
-	// 	return
-	// }
-	// chainID := clientCtx.ChainID
+	clientCtx, error := client.GetClientTxContext(cmd)
+	if error != nil {
+		ctx.Logger.Error(err.Error())
+		return
+	}
+	chainID := clientCtx.ChainID
 
 	var v types.VersionResponse
 	if len(res) > 0 {
 		v = types.VersionResponse{
 			Version: res,
-			ChainID: "test-chain",
+			ChainID: chainID,
 		}
 	} else {
 		v = types.VersionResponse{
 			Version: version.Version,
-			ChainID: "test-chain",
+			ChainID: chainID,
 		}
 	}
 

--- a/jprov/server/http.go
+++ b/jprov/server/http.go
@@ -69,6 +69,7 @@ func checkVersion(cmd *cobra.Command, w http.ResponseWriter, ctx *utils.Context)
 	} else {
 		v = types.VersionResponse{
 			Version: version.Version,
+			ChainID: "test-chain",
 		}
 	}
 

--- a/jprov/server/http.go
+++ b/jprov/server/http.go
@@ -53,14 +53,13 @@ func checkVersion(cmd *cobra.Command, w http.ResponseWriter, ctx *utils.Context)
 		ctx.Logger.Error(err.Error())
 	}
 
-	clientContext := client.GetClientContextFromCmd(cmd)
-	chainID := clientContext.ChainID
+	clientCtx, err := client.GetClientTxContext(cmd)
 
 	var v types.VersionResponse
 	if len(res) > 0 {
 		v = types.VersionResponse{
 			Version: res,
-			ChainID: chainID,
+			ChainID: clientCtx.ChainID,
 		}
 	} else {
 		v = types.VersionResponse{

--- a/jprov/types/types.go
+++ b/jprov/types/types.go
@@ -31,6 +31,7 @@ type ErrorResponse struct {
 
 type VersionResponse struct {
 	Version string `json:"version"`
+	ChainID string `json:"chain-id"`
 }
 
 type Message interface{}


### PR DESCRIPTION
Returns chain-id in the version response to check which network the provider is running on.