### PR TITLE
Aux: Build w/ Go Version 1.20

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,14 +69,14 @@ BUILD_FLAGS := -tags "$(build_tags_comma_sep)" -ldflags '$(ldflags)' -trimpath
 
 all: lint test install
 
-build: go.sum
+build: go.sum check-go-version
 ifeq ($(OS),Windows_NT)
 	exit 1
 else
 	go build -mod=readonly $(BUILD_FLAGS) -o build/jprovd ./jprov/jprovd
 endif
 
-install: go.sum
+install: go.sum check-go-version
 	go install -mod=readonly $(BUILD_FLAGS) ./...
 
 ########################################
@@ -134,4 +134,12 @@ format: format-tools
 .PHONY: all install install-debug \
 	go-mod-cache draw-deps clean build format \
 	test test-all test-build test-cover test-unit test-race \
-	test-sim-import-export \
+	test-sim-import-export check-go-version\
+
+
+# Add check to make sure we are using the proper Go version before proceeding with anything
+check-go-version:
+	@if ! go version | grep -q "go1.20"; then \
+		echo "\033[0;31mERROR:\033[0m Go version 1.20 is required for compiling canined. It looks like you are using" "$(shell go version) \nThere are potential consensus-breaking changes that can occur when running binaries compiled with different versions of Go. Please download Go version 1.20 and retry. Thank you!"; \
+		exit 1; \
+	fi

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/JackalLabs/jackal-provider
 
-go 1.19
+go 1.20
 
 require (
 	github.com/JackalLabs/blanket v0.0.0


### PR DESCRIPTION
We now force providers to be built with golang version 1.20.