### PR TITLE
Fix: Lowering threads

### DIFF
--- a/jprov/jprovd/provider_commands.go
+++ b/jprov/jprovd/provider_commands.go
@@ -36,7 +36,7 @@ func StartServerCommand() *cobra.Command {
 	cmd.Flags().String(types.VersionFlag, "", "The value exposed by the version api to allow for custom deployments.")
 	cmd.Flags().Bool(types.HaltStraysFlag, false, "Debug flag to stop picking up strays.")
 	cmd.Flags().Uint16(types.FlagInterval, 32, "The interval in seconds for which to check proofs. Must be >=1800 if you need a custom interval")
-	cmd.Flags().Uint(types.FlagThreads, 10, "The amount of stray threads.")
+	cmd.Flags().Uint(types.FlagThreads, 3, "The amount of stray threads.")
 	cmd.Flags().Int(types.FlagMaxMisses, 16, "The amount of intervals a provider can miss their proofs before removing a file.")
 	cmd.Flags().Int64(types.FlagChunkSize, 10240, "The size of a single file chunk.")
 	cmd.Flags().Int64(types.FlagStrayInterval, 20, "The interval in seconds to check for new strays.")


### PR DESCRIPTION
With the new stray improvements, providers claim strays insanely quick, this is causing some issues on lower-end machines and as such we're lowering the default for the uninformed. Beefier providers can up this count with the flag.