### PR TITLE
add defer function to close file buffer in WriteFileToDisk()

### DIFF
--- a/jprov/utils/network.go
+++ b/jprov/utils/network.go
@@ -165,7 +165,11 @@ func WriteFileToDisk(cmd *cobra.Command, reader io.Reader, file io.ReaderAt, clo
 	tree = nil // for GC
 
 	f, err := os.OpenFile(GetStoragePathForTree(clientCtx, fid), os.O_WRONLY|os.O_CREATE, 0o666)
-	defer f.Close()
+	defer func() {
+		if tmpErr := f.Close(); tmpErr != nil && err == nil {
+			err = tmpErr
+		}
+	}()
 
 	if err != nil {
 		return fid, r, data, err

--- a/jprov/utils/network.go
+++ b/jprov/utils/network.go
@@ -12,7 +12,6 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
-	"errors"
 
 	"github.com/tendermint/tendermint/libs/log"
 	"github.com/wealdtech/go-merkletree"
@@ -167,7 +166,9 @@ func WriteFileToDisk(cmd *cobra.Command, reader io.Reader, file io.ReaderAt, clo
 
 	f, err := os.OpenFile(GetStoragePathForTree(clientCtx, fid), os.O_WRONLY|os.O_CREATE, 0o666)
 	defer func() {
-		err = errors.Join(err, f.Close())
+		if tmpErr := f.Close(); tmpErr != nil && err == nil {
+			err = tmpErr
+		}
 	}()
 
 	if err != nil {

--- a/jprov/utils/network.go
+++ b/jprov/utils/network.go
@@ -165,14 +165,13 @@ func WriteFileToDisk(cmd *cobra.Command, reader io.Reader, file io.ReaderAt, clo
 	tree = nil // for GC
 
 	f, err := os.OpenFile(GetStoragePathForTree(clientCtx, fid), os.O_WRONLY|os.O_CREATE, 0o666)
+	defer f.Close()
+
 	if err != nil {
 		return fid, r, data, err
 	}
+
 	_, err = f.Write(exportedTree)
-	if err != nil {
-		return fid, r, data, err
-	}
-	err = f.Close()
 	if err != nil {
 		return fid, r, data, err
 	}


### PR DESCRIPTION
https://github.com/JackalLabs/canine-provider/blob/041b1c701abd12eef085f72a6216caef225a5c66/jprov/utils/network.go#L173
File buffer is not closed before the function returns when f.Write() returns an error.
Fix:
Add defer function to close the file buffer.
Error returned from f.Close() is treated with low priority since it's only raised when f.Close() has already been called.