### PR TITLE
Fix: Sequential Proof Slowdown

### DIFF
--- a/jprov/server/attestation.go
+++ b/jprov/server/attestation.go
@@ -111,6 +111,11 @@ func attest(w *http.ResponseWriter, r *http.Request, cmd *cobra.Command, q *queu
 		return
 	}
 
+	if upload.Response == nil {
+		http.Error(*w, fmt.Errorf(upload.Response.RawLog).Error(), http.StatusBadRequest)
+		return
+	}
+
 	if upload.Response.Code != 0 {
 		http.Error(*w, fmt.Errorf(upload.Response.RawLog).Error(), http.StatusBadRequest)
 		return

--- a/jprov/server/proofs.go
+++ b/jprov/server/proofs.go
@@ -462,11 +462,13 @@ func postProofs(cmd *cobra.Command, db *leveldb.DB, q *queue.UploadQueue, ctx *u
 				continue
 			}
 
-			err = postProof(clientCtx, cid, block, db, q, ctx)
-			if err != nil {
-				ctx.Logger.Error(fmt.Sprintf("Posting Proof Error: %v", err))
-				continue
-			}
+			go func() {
+				err = postProof(clientCtx, cid, block, db, q, ctx)
+				if err != nil {
+					ctx.Logger.Error(fmt.Sprintf("Posting Proof Error: %v", err))
+				}
+			}()
+
 			sleep, err := cmd.Flags().GetInt64(types.FlagSleep)
 			if err != nil {
 				ctx.Logger.Error(err.Error())


### PR DESCRIPTION
Proofs are taking longer now due to attestation form creation, to combat this, we multi-thread the attestation request.