### PR TITLE
Fix prune time + node read issues

### DIFF
--- a/jprov/server/file_server.go
+++ b/jprov/server/file_server.go
@@ -235,7 +235,7 @@ func (f *FileServer) Init() error {
 }
 
 func (f *FileServer) RecollectActiveDeals() error {
-	queryActiveDeals, err := f.QueryMyActiveDeals()
+	queryActiveDeals, err := f.QueryOnlyMyActiveDeals()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
From Brochain: 

> Pruning resumes. It seems that if the provider cannot connect to an RPC for whatever reason, it doesn't try again, it exits.


So we make sure pruning never fails while pining the RPC node unless it's the very first attempt.

We also filter out active deals that aren't ours as we go rather than after to make sure our memory usage doesn't spike like crazy.